### PR TITLE
go.mod: use remote version core-geth (not local workspace/vendored)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build
-      run: make build
+      run: go build .
 
     - name: Test
       run: go test -v .

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-build/
+
 # Test binary, built with `go test -c`
 *.test
 
@@ -13,5 +13,3 @@ build/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-
-_workspace/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-.PHONY: build
-
-build:
-	./deps.sh
-	mkdir -p build/bin
-	go build -o build/bin/ancient-store-storj 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ and can be used as a replacement for the core-geth (and go-ethereum) default of 
 ```sh
 > git clone https://github.com/etclabscore/ancient-store-storj.git
 > cd ancient-store-storj
-> make build
-> ./build/bin/ancient-store-storj --help
+> go build .
+> ./ancient-store-storj --help
 ```
 
 

--- a/deps.sh
+++ b/deps.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-mkdir -p _workspace
-[ ! -d _workspace/go-ethereum ] && git clone https://github.com/etclabscore/core-geth.git _workspace/go-ethereum
-cd _workspace/go-ethereum; git fetch origin feat/frozen-remote; git fetch --tags; git checkout origin/feat/frozen-remote; cd ..

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	storj.io/uplink v1.1.2
 )
 
-replace github.com/ethereum/go-ethereum v1.9.18 => ./_workspace/go-ethereum
+replace github.com/ethereum/go-ethereum => github.com/etclabscore/core-geth v1.11.10-0.20200730130117-dc98713fac98

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/etclabscore/core-geth v1.11.8 h1:S7qh74GM67+MiGjJUMhEss/HPQIPGHUHkQO9
 github.com/etclabscore/core-geth v1.11.8/go.mod h1:KW6R3NH7i9r4iUlhPvZ1cfIk276FqVk+HEoKpvojaEo=
 github.com/etclabscore/core-geth v1.11.9-0.20200729175229-53f107278afe h1:Hlji/TMbosG1iUEQ+K0kMT0K8V8tepviVOnsKYjWmuU=
 github.com/etclabscore/core-geth v1.11.9-0.20200729175229-53f107278afe/go.mod h1:f7ruGEYWykct8ph1U9h9boER/K7+hElYoMTtmfZKz8U=
+github.com/etclabscore/core-geth v1.11.10-0.20200730130117-dc98713fac98 h1:LCSmySxawC0SPzQh1jB8tAoZ+GvtDeEk9XM+AM0rnfw=
+github.com/etclabscore/core-geth v1.11.10-0.20200730130117-dc98713fac98/go.mod h1:f7ruGEYWykct8ph1U9h9boER/K7+hElYoMTtmfZKz8U=
 github.com/ethereum/go-ethereum v1.9.18 h1:+vzvufVD7+OfQa07IJP20Z7AGZsJaw0M6JIA/WQcqy8=
 github.com/ethereum/go-ethereum v1.9.18/go.mod h1:JSSTypSMTkGZtAdAChH2wP5dZEvPGh3nUTuDpH+hNrg=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
Uses core-geth revision which fixes the issue
we were working around by using the local workspace
vendor copy.

https://github.com/etclabscore/core-geth/pull/103/commits/22c398565f56905fe9c36db6248d191c49851429

Still using core-geth revision at the feature branch
for remote ancients, now the latest version there.

Signed-off-by: meows <b5c6@protonmail.com>